### PR TITLE
Kia ora my bro - let me fix this for you

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -245,6 +245,7 @@ nnoremap <SPACE>cc :ccl<CR>:pc<CR>:lclose<CR>
 map <SPACE>jj :call VrcQuery()<CR>
 
 " FZF Quick bind
+let $FZF_DEFAULT_COMMAND = 'ag --hidden --ignore .git -l -g ""'
 nnoremap <SPACE>pf :FZF<CR>
 " Print current file path
 nnoremap <SPACE>pd :echo @%<CR>

--- a/vimrc
+++ b/vimrc
@@ -249,8 +249,13 @@ nnoremap <SPACE>pf :FZF<CR>
 " Print current file path
 nnoremap <SPACE>pd :echo @%<CR>
 
-" Ag Quick bind
-nnoremap <SPACE>sp :Ag<CR>
+" Rg Quick bind
+nnoremap <SPACE>sp :Rg<CR>
+" you've got to really shave those milliseconds bro you've got to find a
+" comfortable binding for; :Rg <c-r><c-w><CR>
+vnoremap <SPACE>sp y:Rg <c-r>"<CR>
+
+command! -bang -nargs=* Rg call fzf#vim#grep('rg --line-number --hidden --no-heading --color=always --smart-case '.shellescape(<q-args>),1, fzf#vim#with_preview({'options': '--delimiter : --nth 3..'}), <bang>0)
 
 " Format JSON quickbind, first is for line, second for file
 nnoremap <SPACE>fj :.!python -m json.tool<CR>


### PR DESCRIPTION
Tweaked that FZF default command to highlight silently hidden files for you while still avoiding that ugly `.git` directory. I've also pushed for a better reaching solution written in _the undisputed best language of all time_.

I have a comment in there for you to spark the thought of adding the old "find word under cursor" functionality. I've also added a visual mode finder - added in a sensible way (binding wise).

Note; I've added the custom `Rg` command for you. It essentially just does a ripgrep, and in a tokenising approach only searches for content in files rather than convoluting pathname and content in the search. I understand that this is simply a preference. Now, this tokenisation process - it does actually come at a performance hit, the scale of it though not large enough to impact the speed of my use of it but perhaps you'd prefer performance.